### PR TITLE
Implement QR code parsing utility

### DIFF
--- a/src/qr_system.py
+++ b/src/qr_system.py
@@ -38,6 +38,39 @@ class DynamicQRGenerator:
 
         return qr_data_string, expiry_timestamp
 
+    def parse_qr_code_data(self, qr_data_string: str) -> dict | None:
+        """Parses a QR code data string into its component fields.
+
+        Args:
+            qr_data_string: The raw string embedded in the QR code.
+
+        Returns:
+            Dictionary with keys ``event_id``, ``location_id``, ``timestamp`` and
+            ``signature`` if parsing succeeds, otherwise ``None`` when the
+            string is malformed.
+        """
+        try:
+            parts = {}
+            for item in qr_data_string.split("|"):
+                if ":" not in item:
+                    return None
+                key, value = item.split(":", 1)
+                parts[key] = value
+
+            if not {"E", "LID", "TS", "S"}.issubset(parts.keys()):
+                return None
+
+            timestamp = int(parts["TS"])
+
+            return {
+                "event_id": parts["E"],
+                "location_id": parts["LID"],
+                "timestamp": timestamp,
+                "signature": parts["S"],
+            }
+        except Exception:
+            return None
+
     def verify_qr_code_data(self, qr_data_string: str, current_location_id_for_verification: str, current_time_for_verification: int, validity_window_seconds: int = 300) -> bool:
         """
         Verifies the dynamic QR code data.

--- a/tests/test_qr_system.py
+++ b/tests/test_qr_system.py
@@ -46,6 +46,21 @@ class TestDynamicQRSystem(unittest.TestCase):
         self.assertGreaterEqual(expiry_ts, current_time + self.default_duration - 5) # Allow 5s slack
         self.assertLessEqual(expiry_ts, current_time + self.default_duration + 5)
 
+    def test_parse_qr_code_data_valid(self):
+        qr_data, _ = self.generator.generate_qr_code_data(
+            self.event_id, self.location_id, duration_seconds=self.default_duration
+        )
+        parsed = self.generator.parse_qr_code_data(qr_data)
+        assert parsed is not None
+        self.assertEqual(parsed["event_id"], self.event_id)
+        self.assertEqual(parsed["location_id"], self.location_id)
+        self.assertIsInstance(parsed["timestamp"], int)
+        self.assertEqual(len(parsed["signature"]), 16)
+
+    def test_parse_qr_code_data_malformed(self):
+        parsed = self.generator.parse_qr_code_data("E:bad|no_colon")
+        self.assertIsNone(parsed)
+
 
     def test_verify_qr_code_data_valid(self):
         qr_data, _ = self.generator.generate_qr_code_data(


### PR DESCRIPTION
## Summary
- add `parse_qr_code_data` helper to QR system
- test parsing of QR strings

## Testing
- `pytest -q`
- `pnpm test` *(fails: HTTP request failed)*

------
https://chatgpt.com/codex/tasks/task_e_686981842c508325819a36a0d77b2948